### PR TITLE
Install a targeted version of cassandra

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,8 +1,8 @@
 # file: cassandra/defaults/main.yml
 
 cassandra_install_method: "package"
-cassandra_source_version: "2.0.6"
-cassandra_source_url: "http://archive.apache.org/dist/cassandra/{{cassandra_source_version}}/apache-cassandra-{{cassandra_source_version}}-bin.tar.gz"
+cassandra_version: "2.0.6"
+cassandra_source_url: "http://archive.apache.org/dist/cassandra/{{cassandra_version}}/apache-cassandra-{{cassandra_version}}-bin.tar.gz"
 
 cassandra_user: "cassandra"
 cassandra_group: "cassandra"

--- a/tasks/package.yml
+++ b/tasks/package.yml
@@ -21,7 +21,7 @@
 
 - name: Cassandra | Install the cassandra package
   apt:
-    name: "cassandra"
+    name: "cassandra={{ cassandra_version }}"
     state: present
     update_cache: yes
 

--- a/tasks/source.yml
+++ b/tasks/source.yml
@@ -13,7 +13,7 @@
 - name: Cassandra | Download the Cassandra source release if not yet present
   get_url:
     url: "{{cassandra_source_url}}"
-    dest: "/tmp/apache-cassandra-{{cassandra_source_version}}-bin.tar.gz"
+    dest: "/tmp/apache-cassandra-{{cassandra_version}}-bin.tar.gz"
 
 - name: Cassandra | Make sure the cassandra install dir is present
   file:
@@ -21,12 +21,12 @@
     state: directory
 
 - name: Cassandra | Unpack the compressed cassandra binaries
-  command: tar -xvzf /tmp/apache-cassandra-{{cassandra_source_version}}-bin.tar.gz chdir=/usr/local/etc/cassandra creates=/usr/local/etc/cassandra/apache-cassandra-{{cassandra_source_version}}
+  command: tar -xvzf /tmp/apache-cassandra-{{cassandra_version}}-bin.tar.gz chdir=/usr/local/etc/cassandra creates=/usr/local/etc/cassandra/apache-cassandra-{{cassandra_version}}
 
 - name: Cassandra | Update the symbolic link to the cassandra install
   file:
     path: /usr/local/etc/cassandra/default
-    src: "/usr/local/etc/cassandra/apache-cassandra-{{cassandra_source_version}}"
+    src: "/usr/local/etc/cassandra/apache-cassandra-{{cassandra_version}}"
     state: link
     force: yes
 


### PR DESCRIPTION
Config files change from version to version.  Currently the role installs
cassandra=2.1.2, which contains invalid config options for this release.
This is a work-a-round until #4 is reviewed and merged.

```
JODEWEY-M-D0YN:servo% vagrant up
Bringing machine 'cassandra' up with 'virtualbox' provider...

PLAY RECAP ********************************************************************
cassandra                  : ok=28   changed=21   unreachable=0    failed=0

root@cassandra:~# cassandra -v
2.0.6
```
